### PR TITLE
Forcing node version 11.10.1 due to travis not building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - node
+  - "11.10.1"
 install:
   - yarn
   - npm install -g codecov


### PR DESCRIPTION
https://stackoverflow.com/questions/55059748/travis-jest-typeerror-cannot-assign-to-read-only-property-symbolsymbol-tostr