### PR TITLE
Do not crash if node is missing color

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@types/jest": "^23.3.12",
     "@types/node": "^10.12.12",
-    "@types/three": "^0.93.9",
+    "@types/three": "^0.93.28",
     "clean-webpack-plugin": "^1.0.0",
     "es-check": "^5.0.0",
     "jest": "^23.6.0",

--- a/src/parsers/protobuf/parseInstancedMeshes.ts
+++ b/src/parsers/protobuf/parseInstancedMeshes.ts
@@ -36,7 +36,7 @@ function createCollection(
   // @ts-ignore
   node.properties.forEach(property => {
     const nodeId = Number(property.nodeId);
-    let { treeIndex, transformMatrix } = property;
+    const { treeIndex, transformMatrix } = property;
     if (property.color == null && !hasWarnedAboutMissingColor) {
       hasWarnedAboutMissingColor = true;
       console.warn(

--- a/src/parsers/protobuf/parseInstancedMeshes.ts
+++ b/src/parsers/protobuf/parseInstancedMeshes.ts
@@ -6,6 +6,7 @@ import { ParseData } from '../parseUtils';
 import { Scene } from 'three';
 const globalColor = new THREE.Color();
 const globalMatrix = new THREE.Matrix4();
+let hasWarnedAboutMissingColor = false;
 
 function findMatchingGeometries(geometries: any[]): MatchingGeometries {
   const matchingGeometries: MatchingGeometries = {
@@ -35,7 +36,15 @@ function createCollection(
   // @ts-ignore
   node.properties.forEach(property => {
     const nodeId = Number(property.nodeId);
-    const { color, treeIndex, transformMatrix } = property;
+    let { treeIndex, transformMatrix } = property;
+    if (property.color == null && !hasWarnedAboutMissingColor) {
+      hasWarnedAboutMissingColor = true;
+      console.warn(
+        '3d-web-parser encountered node with missing color while loading',
+        '(using #ff00ff to highlight objects with missing color).',
+      );
+    }
+    const color = property.color == null ? property.color : { rgb: 0xff00ff };
     globalColor.setHex(color.rgb);
     parseInstancedMeshTransformMatrix(globalMatrix, transformMatrix);
     collection.addMapping(nodeId, treeIndex, globalMatrix);

--- a/src/parsers/protobuf/parseMergedMeshes.ts
+++ b/src/parsers/protobuf/parseMergedMeshes.ts
@@ -4,6 +4,7 @@ import { MatchingGeometries } from './protobufUtils';
 import SceneStats from '../../SceneStats';
 import { ParseData } from '../parseUtils';
 const globalColor = new THREE.Color();
+let hasWarnedAboutMissingColor = false;
 
 function findMatchingGeometries(geometries: any[]): MatchingGeometries {
   const matchingGeometries: MatchingGeometries = {
@@ -34,7 +35,16 @@ export default function parse(data: ParseData): MergedMeshGroup {
     let triangleOffset = 0;
     nodes.forEach(node => {
       const nodeId = Number(node.properties[0].nodeId);
-      const { color, treeIndex } = node.properties[0];
+      let { treeIndex } = node.properties[0];
+      if (node.properties[0].color == null && !hasWarnedAboutMissingColor) {
+        hasWarnedAboutMissingColor = true;
+        console.warn(
+          '3d-web-parser encountered node with missing color while loading',
+          '(using #ff00ff to highlight objects with missing color).',
+        );
+      }
+      const color = node.properties[0].color != null ? node.properties[0].color : { rgb: 0xff00ff };
+
       const { triangleCount } = node;
       globalColor.setHex(color.rgb);
       mergedMesh.mappings.add(triangleOffset, triangleCount, nodeId, treeIndex);

--- a/src/parsers/protobuf/parseMergedMeshes.ts
+++ b/src/parsers/protobuf/parseMergedMeshes.ts
@@ -35,7 +35,7 @@ export default function parse(data: ParseData): MergedMeshGroup {
     let triangleOffset = 0;
     nodes.forEach(node => {
       const nodeId = Number(node.properties[0].nodeId);
-      let { treeIndex } = node.properties[0];
+      const { treeIndex } = node.properties[0];
       if (node.properties[0].color == null && !hasWarnedAboutMissingColor) {
         hasWarnedAboutMissingColor = true;
         console.warn(

--- a/src/parsers/protobuf/protobufUtils.ts
+++ b/src/parsers/protobuf/protobufUtils.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 
+let hasWarnedAboutMissingColor = false;
 // reusable variables
 const globalVector = new THREE.Vector3();
 
@@ -12,10 +13,20 @@ export function parsePrimitiveTreeIndex(data: any): number {
 }
 
 export function parsePrimitiveColor(data: any): any {
-  if (data.properties) {
+  if (data.properties && data.properties.color) {
     return data.properties.color.rgb;
   }
-  return data.nodes[0].properties[0].color.rgb;
+  if (data.nodes[0].properties[0].color) {
+    return data.nodes[0].properties[0].color.rgb;
+  }
+  if (!hasWarnedAboutMissingColor) {
+    hasWarnedAboutMissingColor = true;
+    console.warn(
+      '3d-web-parser encountered node with missing color while loading',
+      '(using #ff00ff to highlight objects with missing color).',
+    );
+  }
+  return 0xff00ff;
 }
 
 export interface MatchingGeometries {

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,10 +96,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.12.tgz#e15a9d034d9210f00320ef718a50c4a799417c47"
   integrity sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A==
 
-"@types/three@^0.93.9":
-  version "0.93.9"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.93.9.tgz#2932790342e793427691adb9d8851c68ba9ac6b9"
-  integrity sha512-9DsBTC77r+ZRRoMN4CqZo0cAmtudWYletFPRJeNeCjI95zWBC5mZ+HcZiYRMgsZNTvrtMSQK+nUlqgxXHt+Hvg==
+"@types/three@^0.93.28":
+  version "0.93.28"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.93.28.tgz#ea7241b7fbcb7872d954cab6974ed3fe4f2b81fb"
+  integrity sha512-by65PS1Ziy6JL7f6a/kSXapmm5HMXQpzKAdg4MGk/RDhbwIClzCJezLRdYKPo4QJp8WwtgRSFuQO9XBHil+auw==
 
 "@webassemblyjs/ast@1.7.11":
   version "1.7.11"


### PR DESCRIPTION
Instead, we issue a warning and use a purple color (#ff00ff) 
to highlight objects with missing color.