### PR TITLE
Make nodeIdTreeIndexMap types consistent between protobuf and i3d

### DIFF
--- a/src/parsers/protobuf/main.ts
+++ b/src/parsers/protobuf/main.ts
@@ -171,10 +171,10 @@ export default async function parseProtobuf(
     sector.instancedMeshGroup.createTreeIndexMap();
   }
 
-  const nodeIdTreeIndexMap: {[s: number]: number} = {};
+  const nodeIdTreeIndexMap: Map<number, number> = new Map();
   for (let treeIndex = 0; treeIndex < treeIndexNodeIdMap.length; treeIndex++) {
     const nodeId = treeIndexNodeIdMap[treeIndex];
-    nodeIdTreeIndexMap[nodeId] = treeIndex;
+    nodeIdTreeIndexMap.set(nodeId, treeIndex);
   }
   return { rootSector, sectors, sceneStats, maps: { colorMap, treeIndexNodeIdMap, nodeIdTreeIndexMap } };
 }


### PR DESCRIPTION
This makes the types for Cognite3DModel a lot cleaner.