### PR TITLE
Added id to sectors from API

### DIFF
--- a/src/Sector.ts
+++ b/src/Sector.ts
@@ -7,6 +7,7 @@ import { MergedMeshGroup } from './geometry/MergedMeshGroup';
 import { InstancedMeshGroup } from './geometry/InstancedMeshGroup';
 
 export default class Sector {
+  public readonly id: number;
   public readonly min: THREE.Vector3;
   public readonly max: THREE.Vector3;
   public depth: number;
@@ -19,10 +20,11 @@ export default class Sector {
   public geometryMap: GeometryMap;
   public readonly object3d: THREE.Object3D;
 
-  constructor(min: THREE.Vector3, max: THREE.Vector3) {
+  constructor(id: number, min: THREE.Vector3, max: THREE.Vector3, path?: string) {
+    this.id = id;
     this.min = min;
     this.max = max;
-    this.path = '0/';
+    this.path = path !== undefined ? path : '';
     this.primitiveGroups = [];
     this.mergedMeshGroup = new MergedMeshGroup();
     this.instancedMeshGroup = new InstancedMeshGroup();
@@ -35,8 +37,11 @@ export default class Sector {
 
   addChild(child: Sector) {
     child.parent = this;
-    const childPath = this.path + this.children.length.toString() + '/';
-    child.path = childPath;
+    if (child.path === '') {
+      // Only set child path if not already set
+      const childPath = this.path + this.children.length.toString() + '/';
+      child.path = childPath;
+    }
     this.children.push(child);
     child.depth = this.depth + 1;
     this.object3d.add(child.object3d);

--- a/src/Sector.ts
+++ b/src/Sector.ts
@@ -20,11 +20,11 @@ export default class Sector {
   public geometryMap: GeometryMap;
   public readonly object3d: THREE.Object3D;
 
-  constructor(id: number, min: THREE.Vector3, max: THREE.Vector3, path?: string) {
+  constructor(id: number, min: THREE.Vector3, max: THREE.Vector3) {
     this.id = id;
     this.min = min;
     this.max = max;
-    this.path = path !== undefined ? path : '';
+    this.path = '0/';
     this.primitiveGroups = [];
     this.mergedMeshGroup = new MergedMeshGroup();
     this.instancedMeshGroup = new InstancedMeshGroup();
@@ -37,11 +37,8 @@ export default class Sector {
 
   addChild(child: Sector) {
     child.parent = this;
-    if (child.path === '') {
-      // Only set child path if not already set
-      const childPath = this.path + this.children.length.toString() + '/';
-      child.path = childPath;
-    }
+    const childPath = this.path + this.children.length.toString() + '/';
+    child.path = childPath;
     this.children.push(child);
     child.depth = this.depth + 1;
     this.object3d.add(child.object3d);

--- a/src/__tests__/Sector.test.ts
+++ b/src/__tests__/Sector.test.ts
@@ -5,12 +5,14 @@ import Sector from '../Sector';
 
 describe('Sectors', () => {
   test('constructor', () => {
+    const id = 1234;
     const min = new THREE.Vector3();
     const max = new THREE.Vector3(1, 1, 1);
-    const sector = new Sector(min, max);
+    const sector = new Sector(id, min, max);
+    expect(sector.id).toBe(id);
     expect(sector.min).toBe(min);
     expect(sector.max).toBe(max);
-    expect(sector.path).toBe('0/');
+    expect(sector.path).toEqual('0/');
     expect(sector.parent).toBe(undefined);
     expect(sector.children.length).toBe(0);
 
@@ -21,11 +23,14 @@ describe('Sectors', () => {
   });
 
   test('add child', () => {
+    const id1 = 0;
+    const id2 = 1;
+    const id3 = 2;
     const min = new THREE.Vector3();
     const max = new THREE.Vector3(1, 1, 1);
 
-    const parent = new Sector(min, max);
-    const child1 = new Sector(min, max);
+    const parent = new Sector(id1, min, max);
+    const child1 = new Sector(id2, min, max);
     expect(child1.parent).toBe(undefined);
     expect(parent.children.length).toBe(0);
 
@@ -36,7 +41,7 @@ describe('Sectors', () => {
     expect(parent.object3d.children[0]).toBe(child1.object3d);
     expect(child1.path).toBe('0/0/');
 
-    const child2 = new Sector(min, max);
+    const child2 = new Sector(id3, min, max);
     parent.addChild(child2);
     expect(child2.parent).toBe(parent);
     expect(child2.depth).toBe(parent.depth + 1);
@@ -47,12 +52,14 @@ describe('Sectors', () => {
   });
 
   test('parent bounding box', () => {
+    const id1 = 0;
+    const id2 = 0;
     const parentMin = new THREE.Vector3();
     const parentMax = new THREE.Vector3(1, 1, 1);
     const childMin = new THREE.Vector3();
     const childMax = new THREE.Vector3(0.5, 0.5, 0.5);
-    const parent = new Sector(parentMin, parentMax);
-    const child = new Sector(childMin, childMax);
+    const parent = new Sector(id1, parentMin, parentMax);
+    const child = new Sector(id2, childMin, childMax);
 
     parent.addChild(child);
     expect(
@@ -69,12 +76,16 @@ describe('Sectors', () => {
   });
 
   test('traverse children', () => {
-    const rootSector = new Sector(new THREE.Vector3(), new THREE.Vector3());
-    const rootFirstSector = new Sector(new THREE.Vector3(), new THREE.Vector3());
+    const id1 = 0;
+    const id2 = 1;
+    const id3 = 2;
+    const id4 = 3;
+    const rootSector = new Sector(id1, new THREE.Vector3(), new THREE.Vector3());
+    const rootFirstSector = new Sector(id2, new THREE.Vector3(), new THREE.Vector3());
     rootSector.addChild(rootFirstSector);
-    const rootSecondSector = new Sector(new THREE.Vector3(), new THREE.Vector3());
+    const rootSecondSector = new Sector(id3, new THREE.Vector3(), new THREE.Vector3());
     rootSector.addChild(rootSecondSector);
-    const rootSecondFirstSector = new Sector(new THREE.Vector3(), new THREE.Vector3());
+    const rootSecondFirstSector = new Sector(id4, new THREE.Vector3(), new THREE.Vector3());
     rootSecondSector.addChild(rootSecondFirstSector);
     const expected = [rootSector, rootFirstSector, rootSecondSector, rootSecondFirstSector];
     let counter = 0;

--- a/src/parsers/i3d/main.ts
+++ b/src/parsers/i3d/main.ts
@@ -34,8 +34,7 @@ export function parseFullCustomFile(
   const rootSector = new Sector(
     rootSectorMetadata.sectorId,
     rootSectorMetadata.sectorBBoxMin,
-    rootSectorMetadata.sectorBBoxMax,
-    '0/'
+    rootSectorMetadata.sectorBBoxMax
   );
   maps.sectors[rootSectorMetadata.sectorId] = rootSector;
   const uncompressedValues = fileReader.readUncompressedValues();

--- a/src/parsers/i3d/main.ts
+++ b/src/parsers/i3d/main.ts
@@ -31,7 +31,12 @@ export function parseFullCustomFile(
   // Read root sector
   const rootSectorLength = fileReader.readUint32();
   const rootSectorMetadata = fileReader.readSectorMetadata();
-  const rootSector = new Sector(rootSectorMetadata.sectorBBoxMin, rootSectorMetadata.sectorBBoxMax);
+  const rootSector = new Sector(
+    rootSectorMetadata.sectorId,
+    rootSectorMetadata.sectorBBoxMin,
+    rootSectorMetadata.sectorBBoxMax,
+    '0/'
+  );
   maps.sectors[rootSectorMetadata.sectorId] = rootSector;
   const uncompressedValues = fileReader.readUncompressedValues();
   compressedData[rootSector.path] = fileReader.readCompressedGeometryData(rootSectorLength);
@@ -41,7 +46,7 @@ export function parseFullCustomFile(
     const sectorStartLocation = fileReader.location;
     const sectorByteLength = fileReader.readUint32();
     const sectorMetadata = fileReader.readSectorMetadata();
-    const sector = new Sector(sectorMetadata.sectorBBoxMin, sectorMetadata.sectorBBoxMax);
+    const sector = new Sector(rootSectorMetadata.sectorId, sectorMetadata.sectorBBoxMin, sectorMetadata.sectorBBoxMax);
     maps.sectors[sectorMetadata.sectorId] = sector;
 
     const parentSector = maps.sectors[sectorMetadata.parentSectorId];
@@ -76,7 +81,7 @@ export function parseMultipleCustomFiles(
     const fileReader = new CustomFileReader(sectorBuffer);
     const sectorByteLength = fileReader.readUint32();
     const sectorMetadata = fileReader.readSectorMetadata();
-    const sector = new Sector(sectorMetadata.sectorBBoxMin, sectorMetadata.sectorBBoxMax);
+    const sector = new Sector(sectorMetadata.sectorId, sectorMetadata.sectorBBoxMin, sectorMetadata.sectorBBoxMax);
     maps.sectors[sectorMetadata.sectorId] = sector;
 
     if (sectorMetadata.arrayCount > 0) {

--- a/src/parsers/protobuf/main.ts
+++ b/src/parsers/protobuf/main.ts
@@ -118,10 +118,10 @@ export default function parseProtobuf(
   const colorMap: ColorMap = [];
 
   const handleWebNode = (webNode: any) => {
-    const { boundingBox, path } = webNode;
+    const { boundingBox, path, id } = webNode;
     const boundingBoxMin = new Vector3(boundingBox.min.x, boundingBox.min.y, boundingBox.min.z);
     const boundingBoxMax = new Vector3(boundingBox.max.x, boundingBox.max.y, boundingBox.max.z);
-    const sector = new Sector(boundingBoxMin, boundingBoxMax);
+    const sector = new Sector(id, boundingBoxMin, boundingBoxMax, path);
     sectors[path] = sector;
 
     const { primitiveGroups, mergedMeshGroup, instancedMeshGroup } = parseGeometries({

--- a/src/parsers/protobuf/main.ts
+++ b/src/parsers/protobuf/main.ts
@@ -121,7 +121,7 @@ export default function parseProtobuf(
     const { boundingBox, path, id } = webNode;
     const boundingBoxMin = new Vector3(boundingBox.min.x, boundingBox.min.y, boundingBox.min.z);
     const boundingBoxMax = new Vector3(boundingBox.max.x, boundingBox.max.y, boundingBox.max.z);
-    const sector = new Sector(id, boundingBoxMin, boundingBoxMax, path);
+    const sector = new Sector(id, boundingBoxMin, boundingBoxMax);
     sectors[path] = sector;
 
     const { primitiveGroups, mergedMeshGroup, instancedMeshGroup } = parseGeometries({


### PR DESCRIPTION
If the path is known from the file, store the original one rather than generating. That makes it easier to debug when using bounding box filter.

Also, store the id of the sector.