### PR TITLE
Prevent thread blocking by adding sleep

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/3d-web-parser",
-  "version": "0.9.9",
+  "version": "0.10.0",
   "description": "Parser for Cognite 3D viewer",
   "browser": "dist/main.js",
   "contributors": [

--- a/src/__tests__/Parser.test.ts
+++ b/src/__tests__/Parser.test.ts
@@ -7,15 +7,18 @@ import * as TestScene from './fixtures/test_scene.json';
 import { expectBoundingBoxEqual } from '../TestUtils';
 
 describe('Parser', () => {
-  test('parse sector', () => {
+  test('parse sector', done => {
     const protobufData = fs.readFileSync('./src/__tests__/fixtures/test_scene.pb', null);
-    const { rootSector, maps } = parse(protobufData);
-    expect(rootSector).toBeInstanceOf(Sector);
+    parse(protobufData).then(data => {
+      const { rootSector, maps } = data;
+      expect(rootSector).toBeInstanceOf(Sector);
 
-    // validate bounding box
-    const { boundingBox } = TestScene;
-    expectBoundingBoxEqual(rootSector, boundingBox);
-    expect(rootSector.parent).toBe(undefined);
-    expect(rootSector.children.length).toBe(0);
+      // validate bounding box
+      const { boundingBox } = TestScene;
+      expectBoundingBoxEqual(rootSector, boundingBox);
+      expect(rootSector.parent).toBe(undefined);
+      expect(rootSector.children.length).toBe(0);
+      done();
+    });
   });
 });

--- a/src/parsers/parseUtils.ts
+++ b/src/parsers/parseUtils.ts
@@ -7,6 +7,10 @@ import { InstancedMesh } from '../geometry/InstancedMeshGroup';
 import SceneStats from '../SceneStats';
 import Sector from './../Sector';
 
+export function sleep(timeout: number) {
+  return new Promise(resolve => setTimeout(resolve, timeout));
+}
+
 export interface FilterOptions {
   boundingBoxFilter?: THREE.Box3;
   nodeIdFilter?: number[];


### PR DESCRIPTION
This increases loading time for IAA with 1 second, but does not freeze GUI during parsing which is very nice.