### PR TITLE
Fix instanced mesh bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/3d-web-parser",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Parser for Cognite 3D viewer",
   "browser": "dist/main.js",
   "contributors": [

--- a/src/geometry/InstancedMeshGroup.ts
+++ b/src/geometry/InstancedMeshGroup.ts
@@ -257,17 +257,19 @@ export class InstancedMeshGroup extends GeometryGroup {
     this.meshes.push(mesh);
   }
 
-  removeTreeIndicesFromCollection(treeIndices: number[], collection: InstancedMeshCollection) {
+  removeTreeIndicesFromCollection = (treeIndices: number[], collection: InstancedMeshCollection) => {
     const indicesToRemove: IndexMap = {};
     treeIndices.forEach(treeIndex => {
       this.treeIndexMap[treeIndex].forEach(mesh => {
-        const { meshIndex, mappingIndex, collectionIndex } = mesh;
-        indicesToRemove[mappingIndex] = true;
+        const { mappingIndex, meshIndex, collectionIndex } = mesh;
+        if (this.meshes[meshIndex].collections[collectionIndex] === collection) {
+          indicesToRemove[mappingIndex] = true;
+        }
       });
     });
     collection.mappings.removeIndices(indicesToRemove);
     this.createTreeIndexMap();
-  }
+  };
 
   computeBoundingBox(
     matrix: THREE.Matrix4,

--- a/src/geometry/InstancedMeshGroup.ts
+++ b/src/geometry/InstancedMeshGroup.ts
@@ -62,6 +62,7 @@ export class InstancedMeshMappings {
     }
 
     this.count = newIndex;
+    this.resize(newIndex);
   }
 
   public add(nodeId: number, treeIndex: number, size: number, transformMatrix?: THREE.Matrix4) {

--- a/src/geometry/InstancedMeshGroup.ts
+++ b/src/geometry/InstancedMeshGroup.ts
@@ -53,9 +53,9 @@ export class InstancedMeshMappings {
         this.transform2[3 * newIndex + 1] = this.transform2[3 * i + 1];
         this.transform2[3 * newIndex + 2] = this.transform2[3 * i + 2];
 
-        this.transform3[3 * newIndex + 0] = this.transform1[3 * i + 0];
-        this.transform3[3 * newIndex + 1] = this.transform1[3 * i + 1];
-        this.transform3[3 * newIndex + 2] = this.transform1[3 * i + 2];
+        this.transform3[3 * newIndex + 0] = this.transform3[3 * i + 0];
+        this.transform3[3 * newIndex + 1] = this.transform3[3 * i + 1];
+        this.transform3[3 * newIndex + 2] = this.transform3[3 * i + 2];
 
         newIndex++;
       }


### PR DESCRIPTION
In the viewer, we use the length of the `.size` array on instanced meshes to determine how much we should render. This becomes problematic if a bounding box filter has been applied where the size may be smaller than the full size, and some geometries may be visible that are really removed.

Also, a copy paste bug was fixed.