### PR TITLE
Fix EllipsoidSegment by using height instead of radius

### DIFF
--- a/src/parsers/i3d/unpackGeometry/Ellipsoid.ts
+++ b/src/parsers/i3d/unpackGeometry/Ellipsoid.ts
@@ -20,7 +20,7 @@ function addOpenEllipsoidSegment(
     data.normal,
     data.radiusA,
     data.radiusB,
-    data.radiusB * 2,
+    data.height,
     filterOptions
   );
 }


### PR DESCRIPTION
Previously, an ellipsoid segment would always be rendered as a complete
ellipsoid because height was set to radius * 2.