### PR TITLE
Create treeIndexMap after merging meshes

### DIFF
--- a/src/geometry/MergedMeshGroup.ts
+++ b/src/geometry/MergedMeshGroup.ts
@@ -231,6 +231,15 @@ export class MergedMeshGroup extends GeometryGroup {
   computeBoundingBox(matrix: THREE.Matrix4, box: THREE.Box3, treeIndex: number): THREE.Box3 {
     box.makeEmpty();
 
+    if (!this.treeIndexMap[treeIndex]) {
+      // tslint:disable-next-line:no-console
+      console.warn(
+        `WARNING: Requested treeIndex ${treeIndex} not found in treeIndexMap of ${this}. ` +
+          `The computed bounding box will be empty`
+      );
+      return new THREE.Box3();
+    }
+
     this.treeIndexMap[treeIndex].forEach(mesh => {
       const { meshIndex, mappingIndex } = mesh;
       const mergedMesh = this.meshes[meshIndex];

--- a/src/optimizations/mergeInstancedMeshes.ts
+++ b/src/optimizations/mergeInstancedMeshes.ts
@@ -59,4 +59,8 @@ export default function mergeInstancedMeshes(rootSector: Sector, sceneStats: Sce
       }
     }
   }
+
+  for (const sector of rootSector.traverseSectors()) {
+    sector.mergedMeshGroup.createTreeIndexMap();
+  }
 }


### PR DESCRIPTION
And add a warning if the treeIndex is still missing from the map.